### PR TITLE
Automatically update vsix version

### DIFF
--- a/RaspberryDebugger/RaspberryDebugger.csproj
+++ b/RaspberryDebugger/RaspberryDebugger.csproj
@@ -219,6 +219,48 @@
     </Content>
   </ItemGroup>
   <ItemGroup />
+	<UsingTask TaskName="UpdateVsixManifestVersion" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+		<ParameterGroup>
+			<FilePath ParameterType="System.String" Required="true" />
+			<Version ParameterType="System.String" Required="true" />
+		</ParameterGroup>
+		<Task>
+			<Using Namespace="System" />
+			<Using Namespace="System.IO" />
+			<Using Namespace="System.Text.RegularExpressions" />
+			<Code Type="Fragment" Language="cs">
+				<![CDATA[
+        string content = File.ReadAllText(FilePath);
+        string updatedContent = Regex.Replace(content, 
+          "<Identity Id=\"Raspberry Debugger\\.4f9de82d-0bbe-493c-8c12-9dbd38e93008\" Version=\".*?\" Language=\"en-US\" Publisher=\"GingerMintSoft\" />", 
+          string.Format("<Identity Id=\"Raspberry Debugger.4f9de82d-0bbe-493c-8c12-9dbd38e93008\" Version=\"{0}\" Language=\"en-US\" Publisher=\"GingerMintSoft\" />", Version));
+        File.WriteAllText(FilePath, updatedContent);
+      ]]>
+			</Code>
+		</Task>
+	</UsingTask>
+
+	<Target Name="SetVersion" BeforeTargets="BeforeBuild">
+		<PropertyGroup>
+			<VsixVersion>3.3.$(Year)$(DayOfYear).$(Time)</VsixVersion>
+		</PropertyGroup>
+
+		<ItemGroup>
+			<VsixManifestFile Include="source.extension.vsixmanifest" />
+		</ItemGroup>
+
+		<Message Text="Updating VSIX manifest version to $(VsixVersion)" Importance="High" />
+
+		<UpdateVsixManifestVersion
+			FilePath="source.extension.vsixmanifest"
+			Version="$(VsixVersion)" />
+	</Target>
+
+	<PropertyGroup>
+		<Year>$([System.DateTime]::Now.Year)</Year>
+		<DayOfYear>$([System.DateTime]::Now.DayOfYear)</DayOfYear>
+		<Time>$([System.DateTime]::Now.ToString("HHmm"))</Time>
+	</PropertyGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/RaspberryDebugger/source.extension.vsixmanifest
+++ b/RaspberryDebugger/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Raspberry Debugger.4f9de82d-0bbe-493c-8c12-9dbd38e93008" Version="3.3" Language="en-US" Publisher="GingerMintSoft" />
+        <Identity Id="Raspberry Debugger.4f9de82d-0bbe-493c-8c12-9dbd38e93008" Version="3.3.2024327.1904" Language="en-US" Publisher="GingerMintSoft" />
         <DisplayName>Raspberry Debugger</DisplayName>
         <Description xml:space="preserve">The Raspberry Debugger extension provides an easy way to debug applications on a real Raspberry Pi using Visual Studio 2022.
 Supporting 32 and 64 bit raspbian operating system versions.


### PR DESCRIPTION
Update the vsixmanifest revision & patch versions (major.minor.revision.patch) when building so that the release vsix file can be installed over the top, keeping major.minor as 3.3